### PR TITLE
[APM-9531] feature/update interceptors to capture start end screen name

### DIFF
--- a/Instabug-grpc-objc/InstabugClientInterceptor.m
+++ b/Instabug-grpc-objc/InstabugClientInterceptor.m
@@ -22,6 +22,7 @@
 @property NSInteger duration;
 @property NSString *gRPCMethod;
 @property NSString *serverErrorMessage;
+@property NSString *identifier;
 @property double startTime;
 @property BOOL isServerSideError;
 @end
@@ -40,6 +41,8 @@ GRPCNetworkLog *networkLog;
     networkLog.url = [NSString stringWithFormat:@"grpc://%@/%@",[requestOptions host], [requestOptions path].pathComponents[1]];
     networkLog.gRPCMethod = [requestOptions path].pathComponents[2];
     networkLog.startTime = [[NSDate date] timeIntervalSince1970];
+    networkLog.identifier = [[NSUUID alloc] UUIDString];
+    [IBGNetworkLogger grpcRequestDidStartWithIdentifier:networkLog.identifier];
     networkLog.requestHeaders = [[NSMutableDictionary alloc] initWithDictionary:[callOptions.initialMetadata copy]];
     if (networkLog.requestHeaders[@"content-type"] == nil) {
         [networkLog.requestHeaders setObject:@"application/grpc" forKey:@"content-type"];
@@ -104,7 +107,8 @@ GRPCNetworkLog *networkLog;
                                      errorCode:(int)networkLog.errorCode
                                       duration:networkLog.duration
                                     gRPCMethod:networkLog.gRPCMethod
-                            serverErrorMessage:networkLog.serverErrorMessage];
+                            serverErrorMessage:networkLog.serverErrorMessage
+                                    identifier:networkLog.identifier];
     [super didCloseWithTrailingMetadata:trailingMetadata error:error];
 }
 

--- a/Instabug-grpc-swift/InstabugClientInterceptor.swift
+++ b/Instabug-grpc-swift/InstabugClientInterceptor.swift
@@ -39,6 +39,7 @@ open class InstabugClientInterceptor<Request: InstabugGRPCDataProtocol, Response
         switch part {
         case let .metadata(headers):
             networkLog.startTime = Date().timeIntervalSince1970
+            NetworkLogger.grpcRequestDidStart(withIdentifier: networkLog.identifier)
             for header in headers {
                 networkLog.requestHeaders[header.name] = header.value
             }
@@ -134,7 +135,8 @@ open class InstabugClientInterceptor<Request: InstabugGRPCDataProtocol, Response
             errorCode: networkLog.errorCode ?? 0,
             duration: networkLog.duration ?? 0,
             gRPCMethod: networkLog.gRPCMethod,
-            serverErrorMessage:networkLog.serverErrorMessage)
+            serverErrorMessage:networkLog.serverErrorMessage,
+            identifier: networkLog.identifier)
     }
     
     func getHost(context: ClientInterceptorContext<Request, Response>) -> String {
@@ -177,6 +179,7 @@ struct GRPCNetworkLog {
     var duration: Int64?
     var gRPCMethod: String?
     var serverErrorMessage: String?
+    var identifier = UUID().uuidString
 }
 
 public protocol InstabugGRPCDataProtocol {

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ iOS version >= 10.0
 1. Make sure you import our destination first: `import Instabug_gRPC_Swift`
 2. Create Interceptor factory that confirms to the interceptor factory protocol that you have in your .grpc file
 3. Make sure to return new instance of our Interceptor `InstabugClientInterceptor()` in the methods that you need us to log
-4. You can pass the port optional in `InstabugClientInterceptor` as `InstabugClientInterceptor(port: <#T##Int?#>)` to see it on the dashboard
+4. Then conform on `InstabugGRPCDataProtocol` for request and response models which have data variable `{ get }` and convert your model to `Data` and return that `Data` in that variable for both request and response
+5. You can pass the port optional in `InstabugClientInterceptor` as `InstabugClientInterceptor(port: <#T##Int?#>)` to see it on the dashboard
  
 ### Sample code 
 
@@ -43,6 +44,17 @@ class ExampleClientInterceptorFactory: Echo_EchoClientInterceptorFactoryProtocol
   }
 }
 
+extension GrpcAutomation_ServerErrorRequest: InstabugGRPCDataProtocol {
+    public var gRPCRequestData: Data? {
+        return message.data(using: .utf8)
+    }
+}
+
+extension GrpcAutomation_ServerErrorReply: InstabugGRPCDataProtocol {
+    public var gRPCRequestData: Data? {
+        return message.data(using: .utf8)
+    }
+}
 ```
 
 And finally pass `ExampleClientInterceptorFactory()` to your client like this

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ iOS version >= 10.0
 1. Make sure you import our destination first: `import Instabug_gRPC_Swift`
 2. Create Interceptor factory that confirms to the interceptor factory protocol that you have in your .grpc file
 3. Make sure to return new instance of our Interceptor `InstabugClientInterceptor()` in the methods that you need us to log
-4. Then conform on `InstabugGRPCDataProtocol` for request and response models which have data variable `{ get }` and convert your model to `Data` and return that `Data` in that variable for both request and response
-5. You can pass the port optional in `InstabugClientInterceptor` as `InstabugClientInterceptor(port: <#T##Int?#>)` to see it on the dashboard
+4. You can pass the port optional in `InstabugClientInterceptor` as `InstabugClientInterceptor(port: <#T##Int?#>)` to see it on the dashboard
  
 ### Sample code 
 
@@ -44,17 +43,6 @@ class ExampleClientInterceptorFactory: Echo_EchoClientInterceptorFactoryProtocol
   }
 }
 
-extension GrpcAutomation_ServerErrorRequest: InstabugGRPCDataProtocol {
-    public var gRPCRequestData: Data? {
-        return message.data(using: .utf8)
-    }
-}
-
-extension GrpcAutomation_ServerErrorReply: InstabugGRPCDataProtocol {
-    public var gRPCRequestData: Data? {
-        return message.data(using: .utf8)
-    }
-}
 ```
 
 And finally pass `ExampleClientInterceptorFactory()` to your client like this


### PR DESCRIPTION
## PR comments 
👏 Awesome - Not actionable.
💡 Suggestion - Not actionable.
 [?] Question - Not actionable.
🙇‍♂️ Needs discussion - Actionable.
    Please provide a concrete reason or example on why we need to discuss this?
 ⚠️ Warning - Actionable.
    Only use this for very obvious things that the owner just forgot to fix. 
    
<!-- START OF PR TEMPLATE FOR NEW FEATURE -->

<!-- Please choose the type that accurately describes this PR -->
## PR Type
* [x] Feature
* [ ] Fix
* [ ] Refactoring
* [ ] Optimization

<!-- Please give a summary of the changes introduced in this PR -->

## Summary
Supporting capturing screen names when the request is initiated and when the request is finished to be captured by the sdk and saved in the network trace.

## Changelog
- [Added] - `identifier` parameter to `GRPCNetworkLog` to be sent to the sdk to save start screen name

<!-- Please add any important links related to this PR in this section-->
## Links
- [Story Link](https://instabug.atlassian.net/browse/APM-9531)

<!-- END OF PR TEMPLATE FOR NEW FEATURE -->
